### PR TITLE
delete print statement

### DIFF
--- a/lib/rounded_loading_button.dart
+++ b/lib/rounded_loading_button.dart
@@ -177,7 +177,6 @@ class RoundedLoadingButtonState extends State<RoundedLoadingButton>
 
     _borderAnimation.addListener(() {
       setState(() {});
-      print(_borderAnimation.value);
     });
 
     widget.controller?._addListeners(_start, _stop, _success, _error, _reset);


### PR DESCRIPTION
A lot of logs will be output due to the print statement, so can you delete it?

