### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  rxdart: '>=0.23.1 <=0.25.0'
+  rxdart: ^0.26.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Just update RxDart, because it is causing incompatibilities with cached_network_image null safety.