### PR TITLE
[Bug][#37] disabled color not working anymore

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/lib/rounded_loading_button.dart
+++ b/lib/rounded_loading_button.dart
@@ -161,13 +161,14 @@ class RoundedLoadingButtonState extends State<RoundedLoadingButton>
         disabledColor: widget.disabledColor,
         child: ElevatedButton(
           style: ElevatedButton.styleFrom(
+            onSurface: widget.disabledColor,
             minimumSize: Size(_squeezeAnimation.value, widget.height),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(widget.borderRadius),
             ),
             primary: widget.color,
             elevation: widget.elevation,
-            padding: EdgeInsets.all(0)
+            padding: EdgeInsets.all(0),
           ),
           onPressed: widget.onPressed == null ? null : _btnPressed,
           child: childStream,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
ButtonTheme is deprecated, so passing parameter disabledColor to _onSurface_ below is required.

![Simulator Screen Shot - iPhone 8 - 2021-06-02 at 13 02 23](https://user-images.githubusercontent.com/32274739/120431688-040d5400-c3a3-11eb-9a5c-c85d351148bf.png)
